### PR TITLE
Add watchdog monitor with config and tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt flake8 pytest
+      - run: flake8
+      - run: pytest -q

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+log_file: /var/log/suricata/fast.log
+backup_dir: /var/log/suricata/backups
+telegram_token: "TOKEN_TELEGRAM_BOT"
+chat_id: "CHAT_ID"

--- a/files/monitor_watchdog.py
+++ b/files/monitor_watchdog.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+from pathlib import Path
+from datetime import datetime
+import yaml
+import requests
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+import time
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / 'config.yaml'
+
+
+def load_config(path=CONFIG_PATH):
+    with open(path, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def leer_alertas(log_file):
+    if log_file.exists() and log_file.stat().st_size > 0:
+        with open(log_file, 'r') as f:
+            return f.readlines()
+    return []
+
+
+def enviar_telegram(alertas, token, chat_id):
+    telegram_url = f"https://api.telegram.org/bot{token}/sendDocument"
+    nombre = f"alerta_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
+    tmp_path = Path('/tmp') / nombre
+    with open(tmp_path, 'w') as f:
+        f.writelines(alertas)
+    with open(tmp_path, 'rb') as f:
+        requests.post(
+            telegram_url,
+            data={'chat_id': chat_id, 'caption': '🚨 Nuevas alertas de Suricata'},
+            files={'document': f},
+            timeout=10,
+        )
+    tmp_path.unlink(missing_ok=True)
+
+
+def hacer_backup(log_file, backup_dir):
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    fecha = datetime.now().strftime('%Y%m%d_%H%M%S')
+    backup_file = backup_dir / f"backup_{fecha}.log"
+    with open(log_file, 'r') as src, open(backup_file, 'w') as dst:
+        dst.write(src.read())
+    open(log_file, 'w').close()
+    return backup_file
+
+
+
+
+class LogHandler(FileSystemEventHandler):
+    def __init__(self, log_file, token, chat_id, backup_dir):
+        super().__init__()
+        self.log_file = log_file
+        self.token = token
+        self.chat_id = chat_id
+        self.backup_dir = backup_dir
+
+    def on_modified(self, event):
+        if Path(event.src_path) == self.log_file:
+            alertas = leer_alertas(self.log_file)
+            if alertas:
+                enviar_telegram(alertas, self.token, self.chat_id)
+                hacer_backup(self.log_file, self.backup_dir)
+
+
+def main():
+    cfg = load_config()
+    log_file = Path(cfg['log_file'])
+    backup_dir = Path(cfg['backup_dir'])
+    token = cfg['telegram_token']
+    chat_id = cfg['chat_id']
+
+    handler = LogHandler(log_file, token, chat_id, backup_dir)
+    observer = Observer()
+    observer.schedule(handler, log_file.parent.as_posix(), recursive=False)
+    observer.start()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+PyYAML
+watchdog

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tempfile
+import builtins
+import types
+
+import pytest
+
+from files.monitor_watchdog import leer_alertas, hacer_backup, enviar_telegram
+
+
+class DummyResponse:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+
+    def json(self):
+        return {}
+
+
+def test_leer_alertas(tmp_path):
+    log = tmp_path / "fast.log"
+    log.write_text("alert1\nalert2")
+    lines = leer_alertas(log)
+    assert lines == ["alert1\n", "alert2"]
+
+
+def test_hacer_backup(tmp_path):
+    log = tmp_path / "fast.log"
+    log.write_text("line")
+    backup_dir = tmp_path / "bk"
+    backup_file = hacer_backup(log, backup_dir)
+    assert backup_file.exists()
+    assert backup_file.read_text() == "line"
+    assert log.read_text() == ""
+
+
+def test_enviar_telegram(monkeypatch, tmp_path):
+    recorded = {}
+
+    def fake_post(url, data=None, files=None, timeout=None):
+        recorded['url'] = url
+        recorded['data'] = data
+        recorded['files'] = files
+        return DummyResponse()
+
+    monkeypatch.setattr('requests.post', fake_post)
+    log_content = ["alert"]
+    enviar_telegram(log_content, 'token', 'chat')
+
+    assert recorded['data']['chat_id'] == 'chat'
+    assert 'https://api.telegram.org/bottoken/sendDocument' == recorded['url']
+


### PR DESCRIPTION
## Summary
- implement `monitor_watchdog.py` using `watchdog` and config file
- add default `config.yaml`
- add pytest-based tests covering alert reading, backup creation and telegram sending
- add requirements and flake8 config
- setup GitHub Actions CI

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_688c98ad80e0832b9c46a450265a64f5